### PR TITLE
stringr::str_split_one -> stringr::str_split

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -59,7 +59,7 @@ str_split_one(x, pattern = ",")
 Use `str_split_one()` when the input is known to be a single string.
 For safety, it will error if its input has length greater than one.
 
-`str_split_one()` is built on `stringr::str_split_one()`, so you can use its `n` argument and stringr's general interface for describing the `pattern` to be matched.
+`str_split_one()` is built on `stringr::str_split()`, so you can use its `n` argument and stringr's general interface for describing the `pattern` to be matched.
 
 ```{r}
 str_split_one(x, pattern = ",", n = 2)

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ str_split_one(x, pattern = ",")
 Use `str_split_one()` when the input is known to be a single string. For
 safety, it will error if its input has length greater than one.
 
-`str_split_one()` is built on `stringr::str_split_one()`, so you can use
-its `n` argument and stringr’s general interface for describing the
+`str_split_one()` is built on `stringr::str_split()`, so you can use its
+`n` argument and stringr’s general interface for describing the
 `pattern` to be matched.
 
 ``` r


### PR DESCRIPTION
Sorry if this seems incredibly petty, it's not intended that way. I was interested in the `str_split_one` function of `stringr` (I'd never heard of it before) but found that it didn't exist. The source code lead me to believe you meant `str_split`. Please close if in error. Thanks!