### PR TITLE
Updates 'factor' handling to 'string' handling

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -13,7 +13,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-**NOTE: This is a toy package created for expository purposes, for the second edition of [R Packages](https://r-pkgs.org). It is not meant to actually be useful. If you want a package for factor handling, please see [stringr](https://stringr.tidyverse.org), [stringi](https://stringi.gagolewski.com/),
+**NOTE: This is a toy package created for expository purposes, for the second edition of [R Packages](https://r-pkgs.org). It is not meant to actually be useful. If you want a package for string handling, please see [stringr](https://stringr.tidyverse.org), [stringi](https://stringi.gagolewski.com/),
 [rex](https://cran.r-project.org/package=rex), and
 [rematch2](https://cran.r-project.org/package=rematch2).**
 
@@ -37,7 +37,7 @@ devtools::install_github("jennybc/regexcite")
 ## Usage
 
 A fairly common task when dealing with strings is the need to split a single string into many parts.
-This is what `base::strplit()` and `stringr::str_split()` do.
+This is what `base::strsplit()` and `stringr::str_split()` do.
 
 ```{r}
 (x <- "alfa,bravo,charlie,delta")


### PR DESCRIPTION
Updates *factor* handling to *string* handling for toy package in second edition.
Fixes typo `base::strplit()` to `base::strsplit()`.